### PR TITLE
Bump the version to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "build"
   ],
   "devDependencies": {
-    "@types/bn.js": "^4.11.5",
     "@types/commander": "^2.12.2",
     "@types/lodash": "^4.14.116",
     "@types/node": "^10.7.1",
@@ -35,8 +34,8 @@
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "codechain-keystore": "^0.6.2",
-    "codechain-primitives": "^1.0.3",
+    "codechain-keystore": "^0.6.3",
+    "codechain-primitives": "^1.0.4",
     "commander": "^2.17.1",
     "enquirer": "^2.3.1",
     "lodash": "^4.17.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codechain-keystore-cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A cli tool which manages CodeChain accounts",
   "main": "build/index.js",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,13 +42,6 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@types/bn.js@^4.11.5":
-  version "4.11.5"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.5.tgz#40e36197433f78f807524ec623afcf0169ac81dc"
-  integrity sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==
-  dependencies:
-    "@types/node" "*"
-
 "@types/commander@^2.12.2":
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.12.2.tgz#183041a23842d4281478fa5d23c5ca78e6fd08ae"
@@ -351,35 +344,23 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-codechain-keystore@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/codechain-keystore/-/codechain-keystore-0.6.2.tgz#e377796fe28d8478df01bea9e308dae2a7304182"
-  integrity sha512-uLKUoPbTG5sYb7wnKx+bJ9pRfO/NloDycM24j1qF9LdK/D1psGqZ3XDplz2CCNTC6SV/htuT4l/DZOSynT86Hw==
+codechain-keystore@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/codechain-keystore/-/codechain-keystore-0.6.3.tgz#9042169dd03c9b67ff8e73253a009515dd1e58a5"
+  integrity sha512-bSUhuv9UIXoAKwSWhnylIhnU+BOypd7aqL0E8rPumS5qmsqUZgwMoKCfQBasCVpH+Hm+4fR0CSfVK/J7s/Hvfw==
   dependencies:
     bitcore-mnemonic "^8.6.0"
-    codechain-primitives "^0.3.0"
+    codechain-primitives "^1.0.0"
     config "^2.0.1"
     lodash "^4.17.10"
     lowdb "^1.0.0"
     lowdb-session-storage-adapter "^1.0.0"
     uuid "^3.3.2"
 
-codechain-primitives@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.3.1.tgz#b3a86fdbdf6e95aa5b0313091eff8b65080da9c2"
-  dependencies:
-    bignumber.js "^7.2.1"
-    blakejs "^1.1.0"
-    buffer "^5.2.1"
-    elliptic "^6.4.1"
-    lodash "^4.17.11"
-    ripemd160 "^2.0.2"
-    rlp "^2.1.0"
-
-codechain-primitives@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-1.0.3.tgz#5ae9fa70d803eb109c4ba73f1d2f29275a55fcd9"
-  integrity sha512-B4C+xYj2gH4ukqdmUuWRIZnDz9ewR47q3efT0KPD5UCa/JP+5IG9pGIMDGAZDhJbxCDR6BAQe/SW9wiLm3LHXA==
+codechain-primitives@^1.0.0, codechain-primitives@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-1.0.4.tgz#26918fc5229c3fa0cc8c2d6ecda1ad3740292a4a"
+  integrity sha512-BOA+NL/iHuzp05DC8vLxC2vIMvIHPzREH4sgwcrQKKsnvTMf5frVdBQKBWl6Me2A4M7aa6T+wDe6pAD3WEoJ3w==
   dependencies:
     bignumber.js "^7.2.1"
     blakejs "^1.1.0"
@@ -810,13 +791,6 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-hash-base@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
-
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
@@ -1062,7 +1036,7 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14:
+lodash@4, lodash@^4.17.10, lodash@^4.17.14:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
@@ -1462,13 +1436,6 @@ resolve@^1.3.2:
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
-
-ripemd160@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
 
 rlp@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR bumps the version of the `codechain-primitives` to 1.0.4 and the `codechain-keystore` to 0.6.3.