### PR TITLE
Do not run tests in node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "10"
-  - "8"
 before_install:
   - yarn install
 script:


### PR DESCRIPTION
Node.js 8 LTS version ended at 2019-12-31. Some libraries started not
to support Node.js 8.

https://github.com/nodejs/Release